### PR TITLE
feat: call OnEviction function inline and not in go routine

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -694,11 +694,7 @@ func (c *Cache[K, V]) OnEviction(fn func(context.Context, EvictionReason, *Item[
 	c.events.eviction.mu.Lock()
 	id := c.events.eviction.nextID
 	c.events.eviction.fns[id] = func(r EvictionReason, item *Item[K, V]) {
-		wg.Add(1)
-		go func() {
-			fn(ctx, r, item)
-			wg.Done()
-		}()
+		fn(ctx, r, item)
 	}
 	c.events.eviction.nextID++
 	c.events.eviction.mu.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jellydator/ttlcache/v3
+module github.com/upwindsecurity/go-ttlcache/v3
 
 go 1.18
 


### PR DESCRIPTION
`OnEviction` is used by `PSTree` when the items are being evicted from the cache due to capacity. In the eviction we simply remove reference of the process from a linked list. There is no reason to create go routine for each time it happens.